### PR TITLE
Adds Customization options

### DIFF
--- a/SuperMetroidRandomizer/Customize.Designer.cs
+++ b/SuperMetroidRandomizer/Customize.Designer.cs
@@ -1,0 +1,386 @@
+﻿namespace SuperMetroidRandomizer
+{
+    partial class Customize
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.label1 = new System.Windows.Forms.Label();
+            this.NormalMissiles = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
+            this.SuperMissiles = new System.Windows.Forms.NumericUpDown();
+            this.label3 = new System.Windows.Forms.Label();
+            this.PowerBombs = new System.Windows.Forms.NumericUpDown();
+            this.label4 = new System.Windows.Forms.Label();
+            this.EnergyTanks = new System.Windows.Forms.NumericUpDown();
+            this.AllowHiddenItems = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.ResetControls = new System.Windows.Forms.Button();
+            this.CustomSave = new System.Windows.Forms.Button();
+            this.CustomCancel = new System.Windows.Forms.Button();
+            this.label5 = new System.Windows.Forms.Label();
+            this.Percent = new System.Windows.Forms.Label();
+            this.RouteGen = new System.Windows.Forms.ComboBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.RandomBlanks = new System.Windows.Forms.RadioButton();
+            this.RandomNoBlanks = new System.Windows.Forms.RadioButton();
+            this.label7 = new System.Windows.Forms.Label();
+            this.NoFill = new System.Windows.Forms.RadioButton();
+            ((System.ComponentModel.ISupportInitialize)(this.NormalMissiles)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SuperMissiles)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PowerBombs)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.EnergyTanks)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(40, 73);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(66, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Max Missiles";
+            // 
+            // NormalMissiles
+            // 
+            this.NormalMissiles.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.NormalMissiles.Location = new System.Drawing.Point(163, 71);
+            this.NormalMissiles.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            0});
+            this.NormalMissiles.Name = "NormalMissiles";
+            this.NormalMissiles.ReadOnly = true;
+            this.NormalMissiles.Size = new System.Drawing.Size(42, 20);
+            this.NormalMissiles.TabIndex = 1;
+            this.NormalMissiles.Value = new decimal(new int[] {
+            230,
+            0,
+            0,
+            0});
+            this.NormalMissiles.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(40, 98);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(97, 13);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Max Super Missiles";
+            // 
+            // SuperMissiles
+            // 
+            this.SuperMissiles.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.SuperMissiles.Location = new System.Drawing.Point(163, 96);
+            this.SuperMissiles.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            0});
+            this.SuperMissiles.Name = "SuperMissiles";
+            this.SuperMissiles.ReadOnly = true;
+            this.SuperMissiles.Size = new System.Drawing.Size(42, 20);
+            this.SuperMissiles.TabIndex = 3;
+            this.SuperMissiles.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.SuperMissiles.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(40, 123);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(95, 13);
+            this.label3.TabIndex = 4;
+            this.label3.Text = "Max Power Bombs";
+            // 
+            // PowerBombs
+            // 
+            this.PowerBombs.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.PowerBombs.Location = new System.Drawing.Point(163, 121);
+            this.PowerBombs.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            0});
+            this.PowerBombs.Name = "PowerBombs";
+            this.PowerBombs.ReadOnly = true;
+            this.PowerBombs.Size = new System.Drawing.Size(42, 20);
+            this.PowerBombs.TabIndex = 5;
+            this.PowerBombs.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.PowerBombs.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(40, 150);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(96, 13);
+            this.label4.TabIndex = 6;
+            this.label4.Text = "Max Energy Tanks";
+            // 
+            // EnergyTanks
+            // 
+            this.EnergyTanks.Location = new System.Drawing.Point(163, 148);
+            this.EnergyTanks.Name = "EnergyTanks";
+            this.EnergyTanks.ReadOnly = true;
+            this.EnergyTanks.Size = new System.Drawing.Size(42, 20);
+            this.EnergyTanks.TabIndex = 7;
+            this.EnergyTanks.Value = new decimal(new int[] {
+            14,
+            0,
+            0,
+            0});
+            this.EnergyTanks.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // AllowHiddenItems
+            // 
+            this.AllowHiddenItems.AutoSize = true;
+            this.AllowHiddenItems.Location = new System.Drawing.Point(43, 272);
+            this.AllowHiddenItems.Name = "AllowHiddenItems";
+            this.AllowHiddenItems.Size = new System.Drawing.Size(88, 17);
+            this.AllowHiddenItems.TabIndex = 8;
+            this.AllowHiddenItems.Text = "Hidden Items";
+            this.toolTip1.SetToolTip(this.AllowHiddenItems, "If checked, allows items to be hidden.");
+            this.AllowHiddenItems.UseVisualStyleBackColor = true;
+            // 
+            // ResetControls
+            // 
+            this.ResetControls.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.ResetControls.Location = new System.Drawing.Point(77, 361);
+            this.ResetControls.Name = "ResetControls";
+            this.ResetControls.Size = new System.Drawing.Size(94, 23);
+            this.ResetControls.TabIndex = 9;
+            this.ResetControls.Text = "Reset to Default";
+            this.ResetControls.UseVisualStyleBackColor = true;
+            this.ResetControls.Click += new System.EventHandler(this.ResetControls_Click);
+            // 
+            // CustomSave
+            // 
+            this.CustomSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.CustomSave.Location = new System.Drawing.Point(43, 390);
+            this.CustomSave.Name = "CustomSave";
+            this.CustomSave.Size = new System.Drawing.Size(75, 23);
+            this.CustomSave.TabIndex = 10;
+            this.CustomSave.Text = "Save";
+            this.CustomSave.UseVisualStyleBackColor = true;
+            this.CustomSave.Click += new System.EventHandler(this.CustomSave_Click);
+            // 
+            // CustomCancel
+            // 
+            this.CustomCancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.CustomCancel.Location = new System.Drawing.Point(130, 390);
+            this.CustomCancel.Name = "CustomCancel";
+            this.CustomCancel.Size = new System.Drawing.Size(75, 23);
+            this.CustomCancel.TabIndex = 11;
+            this.CustomCancel.Text = "Cancel";
+            this.CustomCancel.UseVisualStyleBackColor = true;
+            this.CustomCancel.Click += new System.EventHandler(this.CustomCancel_Click);
+            // 
+            // label5
+            // 
+            this.label5.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(12, 305);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(225, 23);
+            this.label5.TabIndex = 12;
+            this.label5.Text = "Max Completion:";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // Percent
+            // 
+            this.Percent.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.Percent.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Percent.Location = new System.Drawing.Point(15, 328);
+            this.Percent.Name = "Percent";
+            this.Percent.Size = new System.Drawing.Size(222, 23);
+            this.Percent.TabIndex = 13;
+            this.Percent.Text = "100%";
+            this.Percent.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // RouteGen
+            // 
+            this.RouteGen.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.RouteGen.FormattingEnabled = true;
+            this.RouteGen.Items.AddRange(new object[] {
+            "Casual",
+            "Speedrunner",
+            "Masochist"});
+            this.RouteGen.Location = new System.Drawing.Point(67, 36);
+            this.RouteGen.Name = "RouteGen";
+            this.RouteGen.Size = new System.Drawing.Size(121, 21);
+            this.RouteGen.TabIndex = 16;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(73, 15);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(113, 16);
+            this.label6.TabIndex = 17;
+            this.label6.Text = "Route Generation";
+            // 
+            // RandomBlanks
+            // 
+            this.RandomBlanks.AutoSize = true;
+            this.RandomBlanks.Enabled = false;
+            this.RandomBlanks.Location = new System.Drawing.Point(43, 217);
+            this.RandomBlanks.Name = "RandomBlanks";
+            this.RandomBlanks.Size = new System.Drawing.Size(81, 17);
+            this.RandomBlanks.TabIndex = 18;
+            this.RandomBlanks.Text = "With blanks";
+            this.toolTip1.SetToolTip(this.RandomBlanks, "Random Items have a chance of being blank.");
+            this.RandomBlanks.UseVisualStyleBackColor = true;
+            this.RandomBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // RandomNoBlanks
+            // 
+            this.RandomNoBlanks.AutoSize = true;
+            this.RandomNoBlanks.Enabled = false;
+            this.RandomNoBlanks.Location = new System.Drawing.Point(43, 241);
+            this.RandomNoBlanks.Name = "RandomNoBlanks";
+            this.RandomNoBlanks.Size = new System.Drawing.Size(74, 17);
+            this.RandomNoBlanks.TabIndex = 19;
+            this.RandomNoBlanks.Text = "No Blanks";
+            this.toolTip1.SetToolTip(this.RandomNoBlanks, "Random items will never be blank.");
+            this.RandomNoBlanks.UseVisualStyleBackColor = true;
+            this.RandomNoBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(40, 178);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(62, 13);
+            this.label7.TabIndex = 20;
+            this.label7.Text = "Random Fill";
+            this.toolTip1.SetToolTip(this.label7, "Randomly fill the remaining item locations with Missiles, Super Missiles, Power B" +
+        "ombs, or Energy Tanks.");
+            // 
+            // NoFill
+            // 
+            this.NoFill.AutoSize = true;
+            this.NoFill.Checked = true;
+            this.NoFill.Enabled = false;
+            this.NoFill.Location = new System.Drawing.Point(43, 194);
+            this.NoFill.Name = "NoFill";
+            this.NoFill.Size = new System.Drawing.Size(54, 17);
+            this.NoFill.TabIndex = 21;
+            this.NoFill.TabStop = true;
+            this.NoFill.Text = "No Fill";
+            this.toolTip1.SetToolTip(this.NoFill, "Disables this feature. (default)");
+            this.NoFill.UseVisualStyleBackColor = true;
+            // 
+            // Customize
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(249, 425);
+            this.Controls.Add(this.NoFill);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.RandomNoBlanks);
+            this.Controls.Add(this.RandomBlanks);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.RouteGen);
+            this.Controls.Add(this.Percent);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.CustomCancel);
+            this.Controls.Add(this.CustomSave);
+            this.Controls.Add(this.ResetControls);
+            this.Controls.Add(this.AllowHiddenItems);
+            this.Controls.Add(this.EnergyTanks);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.PowerBombs);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.SuperMissiles);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.NormalMissiles);
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "Customize";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Customize";
+            this.Load += new System.EventHandler(this.Customize_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.NormalMissiles)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SuperMissiles)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PowerBombs)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.EnergyTanks)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.NumericUpDown NormalMissiles;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.NumericUpDown SuperMissiles;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.NumericUpDown PowerBombs;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.NumericUpDown EnergyTanks;
+        private System.Windows.Forms.CheckBox AllowHiddenItems;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Button ResetControls;
+        private System.Windows.Forms.Button CustomSave;
+        private System.Windows.Forms.Button CustomCancel;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label Percent;
+        private System.Windows.Forms.ComboBox RouteGen;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.RadioButton RandomBlanks;
+        private System.Windows.Forms.RadioButton RandomNoBlanks;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.RadioButton NoFill;
+    }
+}

--- a/SuperMetroidRandomizer/Customize.Designer.cs
+++ b/SuperMetroidRandomizer/Customize.Designer.cs
@@ -74,7 +74,7 @@
             0});
             this.NormalMissiles.Location = new System.Drawing.Point(163, 71);
             this.NormalMissiles.Maximum = new decimal(new int[] {
-            500,
+            390,
             0,
             0,
             0});
@@ -107,7 +107,12 @@
             0});
             this.SuperMissiles.Location = new System.Drawing.Point(163, 96);
             this.SuperMissiles.Maximum = new decimal(new int[] {
-            500,
+            395,
+            0,
+            0,
+            0});
+            this.SuperMissiles.Minimum = new decimal(new int[] {
+            5,
             0,
             0,
             0});
@@ -140,7 +145,12 @@
             0});
             this.PowerBombs.Location = new System.Drawing.Point(163, 121);
             this.PowerBombs.Maximum = new decimal(new int[] {
-            500,
+            395,
+            0,
+            0,
+            0});
+            this.PowerBombs.Minimum = new decimal(new int[] {
+            5,
             0,
             0,
             0});
@@ -167,10 +177,16 @@
             // EnergyTanks
             // 
             this.EnergyTanks.Location = new System.Drawing.Point(163, 148);
+            this.EnergyTanks.Maximum = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
             this.EnergyTanks.Name = "EnergyTanks";
             this.EnergyTanks.ReadOnly = true;
             this.EnergyTanks.Size = new System.Drawing.Size(42, 20);
             this.EnergyTanks.TabIndex = 7;
+            this.toolTip1.SetToolTip(this.EnergyTanks, "Warning: Increase at own risk. Numbers higher than 14 can cause glitchy results.");
             this.EnergyTanks.Value = new decimal(new int[] {
             14,
             0,

--- a/SuperMetroidRandomizer/Customize.Designer.cs
+++ b/SuperMetroidRandomizer/Customize.Designer.cs
@@ -39,6 +39,10 @@
             this.EnergyTanks = new System.Windows.Forms.NumericUpDown();
             this.AllowHiddenItems = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.RandomBlanks = new System.Windows.Forms.RadioButton();
+            this.RandomNoBlanks = new System.Windows.Forms.RadioButton();
+            this.label7 = new System.Windows.Forms.Label();
+            this.NoFill = new System.Windows.Forms.RadioButton();
             this.ResetControls = new System.Windows.Forms.Button();
             this.CustomSave = new System.Windows.Forms.Button();
             this.CustomCancel = new System.Windows.Forms.Button();
@@ -46,24 +50,30 @@
             this.Percent = new System.Windows.Forms.Label();
             this.RouteGen = new System.Windows.Forms.ComboBox();
             this.label6 = new System.Windows.Forms.Label();
-            this.RandomBlanks = new System.Windows.Forms.RadioButton();
-            this.RandomNoBlanks = new System.Windows.Forms.RadioButton();
-            this.label7 = new System.Windows.Forms.Label();
-            this.NoFill = new System.Windows.Forms.RadioButton();
+            this.Minlbl = new System.Windows.Forms.Label();
+            this.Maxlbl = new System.Windows.Forms.Label();
+            this.NormalMissilesMax = new System.Windows.Forms.NumericUpDown();
+            this.SuperMissilesMax = new System.Windows.Forms.NumericUpDown();
+            this.PowerBombsMax = new System.Windows.Forms.NumericUpDown();
+            this.EnergyTanksMax = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)(this.NormalMissiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.SuperMissiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PowerBombs)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.EnergyTanks)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NormalMissilesMax)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SuperMissilesMax)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PowerBombsMax)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.EnergyTanksMax)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(40, 73);
+            this.label1.Location = new System.Drawing.Point(40, 96);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(66, 13);
+            this.label1.Size = new System.Drawing.Size(43, 13);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Max Missiles";
+            this.label1.Text = "Missiles";
             // 
             // NormalMissiles
             // 
@@ -72,7 +82,7 @@
             0,
             0,
             0});
-            this.NormalMissiles.Location = new System.Drawing.Point(163, 71);
+            this.NormalMissiles.Location = new System.Drawing.Point(146, 94);
             this.NormalMissiles.Maximum = new decimal(new int[] {
             390,
             0,
@@ -92,11 +102,11 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(40, 98);
+            this.label2.Location = new System.Drawing.Point(40, 121);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(97, 13);
+            this.label2.Size = new System.Drawing.Size(74, 13);
             this.label2.TabIndex = 2;
-            this.label2.Text = "Max Super Missiles";
+            this.label2.Text = "Super Missiles";
             // 
             // SuperMissiles
             // 
@@ -105,7 +115,7 @@
             0,
             0,
             0});
-            this.SuperMissiles.Location = new System.Drawing.Point(163, 96);
+            this.SuperMissiles.Location = new System.Drawing.Point(146, 119);
             this.SuperMissiles.Maximum = new decimal(new int[] {
             395,
             0,
@@ -130,11 +140,11 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(40, 123);
+            this.label3.Location = new System.Drawing.Point(40, 146);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(95, 13);
+            this.label3.Size = new System.Drawing.Size(72, 13);
             this.label3.TabIndex = 4;
-            this.label3.Text = "Max Power Bombs";
+            this.label3.Text = "Power Bombs";
             // 
             // PowerBombs
             // 
@@ -143,7 +153,7 @@
             0,
             0,
             0});
-            this.PowerBombs.Location = new System.Drawing.Point(163, 121);
+            this.PowerBombs.Location = new System.Drawing.Point(146, 144);
             this.PowerBombs.Maximum = new decimal(new int[] {
             395,
             0,
@@ -168,15 +178,15 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(40, 150);
+            this.label4.Location = new System.Drawing.Point(40, 173);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(96, 13);
+            this.label4.Size = new System.Drawing.Size(73, 13);
             this.label4.TabIndex = 6;
-            this.label4.Text = "Max Energy Tanks";
+            this.label4.Text = "Energy Tanks";
             // 
             // EnergyTanks
             // 
-            this.EnergyTanks.Location = new System.Drawing.Point(163, 148);
+            this.EnergyTanks.Location = new System.Drawing.Point(146, 171);
             this.EnergyTanks.Maximum = new decimal(new int[] {
             40,
             0,
@@ -197,7 +207,7 @@
             // AllowHiddenItems
             // 
             this.AllowHiddenItems.AutoSize = true;
-            this.AllowHiddenItems.Location = new System.Drawing.Point(43, 272);
+            this.AllowHiddenItems.Location = new System.Drawing.Point(43, 295);
             this.AllowHiddenItems.Name = "AllowHiddenItems";
             this.AllowHiddenItems.Size = new System.Drawing.Size(88, 17);
             this.AllowHiddenItems.TabIndex = 8;
@@ -205,10 +215,58 @@
             this.toolTip1.SetToolTip(this.AllowHiddenItems, "If checked, allows items to be hidden.");
             this.AllowHiddenItems.UseVisualStyleBackColor = true;
             // 
+            // RandomBlanks
+            // 
+            this.RandomBlanks.AutoSize = true;
+            this.RandomBlanks.Location = new System.Drawing.Point(43, 240);
+            this.RandomBlanks.Name = "RandomBlanks";
+            this.RandomBlanks.Size = new System.Drawing.Size(81, 17);
+            this.RandomBlanks.TabIndex = 18;
+            this.RandomBlanks.Text = "With blanks";
+            this.toolTip1.SetToolTip(this.RandomBlanks, "Random Items have a chance of being blank.");
+            this.RandomBlanks.UseVisualStyleBackColor = true;
+            this.RandomBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // RandomNoBlanks
+            // 
+            this.RandomNoBlanks.AutoSize = true;
+            this.RandomNoBlanks.Location = new System.Drawing.Point(43, 264);
+            this.RandomNoBlanks.Name = "RandomNoBlanks";
+            this.RandomNoBlanks.Size = new System.Drawing.Size(74, 17);
+            this.RandomNoBlanks.TabIndex = 19;
+            this.RandomNoBlanks.Text = "No Blanks";
+            this.toolTip1.SetToolTip(this.RandomNoBlanks, "Random items will never be blank.");
+            this.RandomNoBlanks.UseVisualStyleBackColor = true;
+            this.RandomNoBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(40, 201);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(62, 13);
+            this.label7.TabIndex = 20;
+            this.label7.Text = "Random Fill";
+            this.toolTip1.SetToolTip(this.label7, "Randomly fill the remaining item locations with Missiles, Super Missiles, Power B" +
+        "ombs, or Energy Tanks.");
+            // 
+            // NoFill
+            // 
+            this.NoFill.AutoSize = true;
+            this.NoFill.Checked = true;
+            this.NoFill.Location = new System.Drawing.Point(43, 217);
+            this.NoFill.Name = "NoFill";
+            this.NoFill.Size = new System.Drawing.Size(54, 17);
+            this.NoFill.TabIndex = 21;
+            this.NoFill.TabStop = true;
+            this.NoFill.Text = "No Fill";
+            this.toolTip1.SetToolTip(this.NoFill, "Disables this feature. (default)");
+            this.NoFill.UseVisualStyleBackColor = true;
+            // 
             // ResetControls
             // 
             this.ResetControls.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.ResetControls.Location = new System.Drawing.Point(77, 361);
+            this.ResetControls.Location = new System.Drawing.Point(77, 396);
             this.ResetControls.Name = "ResetControls";
             this.ResetControls.Size = new System.Drawing.Size(94, 23);
             this.ResetControls.TabIndex = 9;
@@ -219,7 +277,7 @@
             // CustomSave
             // 
             this.CustomSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.CustomSave.Location = new System.Drawing.Point(43, 390);
+            this.CustomSave.Location = new System.Drawing.Point(43, 425);
             this.CustomSave.Name = "CustomSave";
             this.CustomSave.Size = new System.Drawing.Size(75, 23);
             this.CustomSave.TabIndex = 10;
@@ -230,7 +288,7 @@
             // CustomCancel
             // 
             this.CustomCancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.CustomCancel.Location = new System.Drawing.Point(130, 390);
+            this.CustomCancel.Location = new System.Drawing.Point(130, 425);
             this.CustomCancel.Name = "CustomCancel";
             this.CustomCancel.Size = new System.Drawing.Size(75, 23);
             this.CustomCancel.TabIndex = 11;
@@ -242,7 +300,7 @@
             // 
             this.label5.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(12, 305);
+            this.label5.Location = new System.Drawing.Point(12, 340);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(225, 23);
             this.label5.TabIndex = 12;
@@ -253,7 +311,7 @@
             // 
             this.Percent.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.Percent.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Percent.Location = new System.Drawing.Point(15, 328);
+            this.Percent.Location = new System.Drawing.Point(15, 363);
             this.Percent.Name = "Percent";
             this.Percent.Size = new System.Drawing.Size(222, 23);
             this.Percent.TabIndex = 13;
@@ -283,62 +341,147 @@
             this.label6.TabIndex = 17;
             this.label6.Text = "Route Generation";
             // 
-            // RandomBlanks
+            // Minlbl
             // 
-            this.RandomBlanks.AutoSize = true;
-            this.RandomBlanks.Enabled = false;
-            this.RandomBlanks.Location = new System.Drawing.Point(43, 217);
-            this.RandomBlanks.Name = "RandomBlanks";
-            this.RandomBlanks.Size = new System.Drawing.Size(81, 17);
-            this.RandomBlanks.TabIndex = 18;
-            this.RandomBlanks.Text = "With blanks";
-            this.toolTip1.SetToolTip(this.RandomBlanks, "Random Items have a chance of being blank.");
-            this.RandomBlanks.UseVisualStyleBackColor = true;
-            this.RandomBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            this.Minlbl.AutoSize = true;
+            this.Minlbl.Location = new System.Drawing.Point(150, 78);
+            this.Minlbl.Name = "Minlbl";
+            this.Minlbl.Size = new System.Drawing.Size(24, 13);
+            this.Minlbl.TabIndex = 22;
+            this.Minlbl.Text = "Min";
+            this.Minlbl.Visible = false;
             // 
-            // RandomNoBlanks
+            // Maxlbl
             // 
-            this.RandomNoBlanks.AutoSize = true;
-            this.RandomNoBlanks.Enabled = false;
-            this.RandomNoBlanks.Location = new System.Drawing.Point(43, 241);
-            this.RandomNoBlanks.Name = "RandomNoBlanks";
-            this.RandomNoBlanks.Size = new System.Drawing.Size(74, 17);
-            this.RandomNoBlanks.TabIndex = 19;
-            this.RandomNoBlanks.Text = "No Blanks";
-            this.toolTip1.SetToolTip(this.RandomNoBlanks, "Random items will never be blank.");
-            this.RandomNoBlanks.UseVisualStyleBackColor = true;
-            this.RandomNoBlanks.CheckedChanged += new System.EventHandler(this.ValueChanged);
+            this.Maxlbl.AutoSize = true;
+            this.Maxlbl.Location = new System.Drawing.Point(197, 78);
+            this.Maxlbl.Name = "Maxlbl";
+            this.Maxlbl.Size = new System.Drawing.Size(27, 13);
+            this.Maxlbl.TabIndex = 23;
+            this.Maxlbl.Text = "Max";
+            this.Maxlbl.Visible = false;
             // 
-            // label7
+            // NormalMissilesMax
             // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(40, 178);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(62, 13);
-            this.label7.TabIndex = 20;
-            this.label7.Text = "Random Fill";
-            this.toolTip1.SetToolTip(this.label7, "Randomly fill the remaining item locations with Missiles, Super Missiles, Power B" +
-        "ombs, or Energy Tanks.");
+            this.NormalMissilesMax.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.NormalMissilesMax.Location = new System.Drawing.Point(195, 93);
+            this.NormalMissilesMax.Maximum = new decimal(new int[] {
+            390,
+            0,
+            0,
+            0});
+            this.NormalMissilesMax.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.NormalMissilesMax.Name = "NormalMissilesMax";
+            this.NormalMissilesMax.ReadOnly = true;
+            this.NormalMissilesMax.Size = new System.Drawing.Size(42, 20);
+            this.NormalMissilesMax.TabIndex = 24;
+            this.NormalMissilesMax.Value = new decimal(new int[] {
+            230,
+            0,
+            0,
+            0});
+            this.NormalMissilesMax.Visible = false;
+            this.NormalMissilesMax.ValueChanged += new System.EventHandler(this.ValueChanged);
             // 
-            // NoFill
+            // SuperMissilesMax
             // 
-            this.NoFill.AutoSize = true;
-            this.NoFill.Checked = true;
-            this.NoFill.Enabled = false;
-            this.NoFill.Location = new System.Drawing.Point(43, 194);
-            this.NoFill.Name = "NoFill";
-            this.NoFill.Size = new System.Drawing.Size(54, 17);
-            this.NoFill.TabIndex = 21;
-            this.NoFill.TabStop = true;
-            this.NoFill.Text = "No Fill";
-            this.toolTip1.SetToolTip(this.NoFill, "Disables this feature. (default)");
-            this.NoFill.UseVisualStyleBackColor = true;
+            this.SuperMissilesMax.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.SuperMissilesMax.Location = new System.Drawing.Point(195, 118);
+            this.SuperMissilesMax.Maximum = new decimal(new int[] {
+            395,
+            0,
+            0,
+            0});
+            this.SuperMissilesMax.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.SuperMissilesMax.Name = "SuperMissilesMax";
+            this.SuperMissilesMax.ReadOnly = true;
+            this.SuperMissilesMax.Size = new System.Drawing.Size(42, 20);
+            this.SuperMissilesMax.TabIndex = 25;
+            this.SuperMissilesMax.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.SuperMissilesMax.Visible = false;
+            this.SuperMissilesMax.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // PowerBombsMax
+            // 
+            this.PowerBombsMax.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.PowerBombsMax.Location = new System.Drawing.Point(195, 143);
+            this.PowerBombsMax.Maximum = new decimal(new int[] {
+            395,
+            0,
+            0,
+            0});
+            this.PowerBombsMax.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.PowerBombsMax.Name = "PowerBombsMax";
+            this.PowerBombsMax.ReadOnly = true;
+            this.PowerBombsMax.Size = new System.Drawing.Size(42, 20);
+            this.PowerBombsMax.TabIndex = 26;
+            this.PowerBombsMax.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.PowerBombsMax.Visible = false;
+            this.PowerBombsMax.ValueChanged += new System.EventHandler(this.ValueChanged);
+            // 
+            // EnergyTanksMax
+            // 
+            this.EnergyTanksMax.Location = new System.Drawing.Point(195, 170);
+            this.EnergyTanksMax.Maximum = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.EnergyTanksMax.Name = "EnergyTanksMax";
+            this.EnergyTanksMax.ReadOnly = true;
+            this.EnergyTanksMax.Size = new System.Drawing.Size(42, 20);
+            this.EnergyTanksMax.TabIndex = 27;
+            this.EnergyTanksMax.Value = new decimal(new int[] {
+            14,
+            0,
+            0,
+            0});
+            this.EnergyTanksMax.Visible = false;
+            this.EnergyTanksMax.ValueChanged += new System.EventHandler(this.ValueChanged);
             // 
             // Customize
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(249, 425);
+            this.ClientSize = new System.Drawing.Size(249, 460);
+            this.Controls.Add(this.EnergyTanksMax);
+            this.Controls.Add(this.PowerBombsMax);
+            this.Controls.Add(this.SuperMissilesMax);
+            this.Controls.Add(this.NormalMissilesMax);
+            this.Controls.Add(this.Maxlbl);
+            this.Controls.Add(this.Minlbl);
             this.Controls.Add(this.NoFill);
             this.Controls.Add(this.label7);
             this.Controls.Add(this.RandomNoBlanks);
@@ -370,6 +513,10 @@
             ((System.ComponentModel.ISupportInitialize)(this.SuperMissiles)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PowerBombs)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.EnergyTanks)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NormalMissilesMax)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SuperMissilesMax)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PowerBombsMax)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.EnergyTanksMax)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -398,5 +545,11 @@
         private System.Windows.Forms.RadioButton RandomNoBlanks;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.RadioButton NoFill;
+        private System.Windows.Forms.Label Minlbl;
+        private System.Windows.Forms.Label Maxlbl;
+        private System.Windows.Forms.NumericUpDown NormalMissilesMax;
+        private System.Windows.Forms.NumericUpDown SuperMissilesMax;
+        private System.Windows.Forms.NumericUpDown PowerBombsMax;
+        private System.Windows.Forms.NumericUpDown EnergyTanksMax;
     }
 }

--- a/SuperMetroidRandomizer/Customize.cs
+++ b/SuperMetroidRandomizer/Customize.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using SuperMetroidRandomizer.Properties;
+using SuperMetroidRandomizer.Random;
+
+namespace SuperMetroidRandomizer
+{
+    public partial class Customize : Form
+    {
+        // Used to set starting values based on difficulty chosen
+        RandomizerDifficulty DifficultyDefault;
+
+        public Customize()
+        {
+            InitializeComponent();
+        }
+        public Customize(RandomizerDifficulty diff)
+        {
+            InitializeComponent();
+            DifficultyDefault = diff;
+        }
+
+        private void Customize_Load(object sender, EventArgs e)
+        {
+            SetDefaults();
+        }
+
+        private void SetDefaults()
+        {
+            switch(DifficultyDefault)
+            {
+                case RandomizerDifficulty.Casual:
+                    NormalMissiles.Value = 230;
+                    SuperMissiles.Value = 50;
+                    PowerBombs.Value = 50;
+                    EnergyTanks.Value = 14;
+                    AllowHiddenItems.Checked = false;
+                    RouteGen.SelectedItem = "Casual";
+                    break;
+                case RandomizerDifficulty.Speedrunner:
+                    NormalMissiles.Value = 50;
+                    SuperMissiles.Value = 30;
+                    PowerBombs.Value = 20;
+                    EnergyTanks.Value = 7;
+                    AllowHiddenItems.Checked = true;
+                    RouteGen.SelectedItem = "Speedrunner";
+                    break;
+                case RandomizerDifficulty.Masochist:
+                    NormalMissiles.Value = 15;
+                    SuperMissiles.Value = 15;
+                    PowerBombs.Value = 15;
+                    EnergyTanks.Value = 3;
+                    AllowHiddenItems.Checked = true;
+                    RouteGen.SelectedItem = "Masochist";
+                    break;
+                default:
+                    NormalMissiles.Value = Settings.Default.CustomNormalMissiles;
+                    SuperMissiles.Value = Settings.Default.CustomSuperMissiles;
+                    PowerBombs.Value = Settings.Default.CustomPowerBombs;
+                    EnergyTanks.Value = Settings.Default.CustomEnergyTanks;
+                    AllowHiddenItems.Checked = Settings.Default.CustomHiddenItems;
+                    RouteGen.SelectedItem = Settings.Default.CustomRouteGen;
+                    break;
+            }
+        }
+
+        private void CustomSave_Click(object sender, EventArgs e)
+        {
+            Settings.Default.CustomNormalMissiles = NormalMissiles.Value;
+            Settings.Default.CustomSuperMissiles = SuperMissiles.Value;
+            Settings.Default.CustomPowerBombs = PowerBombs.Value;
+            Settings.Default.CustomEnergyTanks = EnergyTanks.Value;
+            Settings.Default.CustomHiddenItems = AllowHiddenItems.Checked;
+            Settings.Default.CustomRouteGen = RouteGen.SelectedItem.ToString();
+
+            if (NoFill.Checked)
+                Settings.Default.CustomRandomBlanks = Settings.Default.CustomRandomNoBlanks = false;
+            else if (RandomBlanks.Checked)
+            {
+                Settings.Default.CustomRandomBlanks = true;
+                Settings.Default.CustomRandomNoBlanks = false;
+            }
+            else
+            {
+                Settings.Default.CustomRandomBlanks = false;
+                Settings.Default.CustomRandomNoBlanks = true;
+            }
+
+            Settings.Default.UseCustomSettings = true;
+            Settings.Default.Save();
+            Close();
+        }
+
+        private void CustomCancel_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void ResetControls_Click(object sender, EventArgs e)
+        {
+            SetDefaults();
+        }
+
+        private void ValueChanged(object sender, EventArgs e)
+        {
+            decimal percent = CalculatePercentage();
+            if (percent > 100)
+                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = CustomSave.Enabled = false;
+            else if (percent == 100)
+            {
+                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = false;
+                CustomSave.Enabled = true;
+            }
+            else
+                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = CustomSave.Enabled = true;
+
+            if (NoFill.Enabled && !NoFill.Checked)
+            {
+                label1.Text = label1.Text.Replace("Max", "Min");
+                label2.Text = label2.Text.Replace("Max", "Min");
+                label3.Text = label3.Text.Replace("Max", "Min");
+                label4.Text = label4.Text.Replace("Max", "Min");
+            }
+            else
+            {
+                label1.Text = label1.Text.Replace("Min", "Max");
+                label2.Text = label2.Text.Replace("Min", "Max");
+                label3.Text = label3.Text.Replace("Min", "Max");
+                label4.Text = label4.Text.Replace("Min", "Max");
+            }
+
+            if (RandomBlanks.Enabled && RandomBlanks.Checked)
+                Percent.Text = "??%";
+            else if (RandomNoBlanks.Enabled && RandomNoBlanks.Checked)
+                Percent.Text = "100%";
+            else
+                Percent.Text = string.Format("{0}%", percent);
+        }
+
+        private decimal CalculatePercentage()
+        {
+            decimal start = 0;
+            switch(DifficultyDefault)
+            {
+                case RandomizerDifficulty.Casual:
+                    start = 20;
+                    break;
+                case RandomizerDifficulty.Speedrunner:
+                    start = 23;
+                    break;
+                case RandomizerDifficulty.Masochist:
+                    start = 16;
+                    break;
+                default:
+                    start = 20;
+                    break;
+            }
+
+            start += (NormalMissiles.Value / 5) + (SuperMissiles.Value / 5) + (PowerBombs.Value / 5) + EnergyTanks.Value;
+            return start;
+        }
+    }
+}

--- a/SuperMetroidRandomizer/Customize.cs
+++ b/SuperMetroidRandomizer/Customize.cs
@@ -14,13 +14,13 @@ namespace SuperMetroidRandomizer
     public partial class Customize : Form
     {
         // Used to set starting values based on difficulty chosen
-        RandomizerDifficulty DifficultyDefault;
+        string DifficultyDefault;
 
         public Customize()
         {
             InitializeComponent();
         }
-        public Customize(RandomizerDifficulty diff)
+        public Customize(string diff)
         {
             InitializeComponent();
             DifficultyDefault = diff;
@@ -35,27 +35,39 @@ namespace SuperMetroidRandomizer
         {
             switch(DifficultyDefault)
             {
-                case RandomizerDifficulty.Casual:
+                case "Casual":
                     NormalMissiles.Value = 230;
+                    NormalMissilesMax.Value = 230;
                     SuperMissiles.Value = 50;
+                    SuperMissilesMax.Value = 50;
                     PowerBombs.Value = 50;
+                    PowerBombsMax.Value = 50;
                     EnergyTanks.Value = 14;
+                    EnergyTanksMax.Value = 14;
                     AllowHiddenItems.Checked = false;
                     RouteGen.SelectedItem = "Casual";
                     break;
-                case RandomizerDifficulty.Speedrunner:
+                case "Speedrunner":
                     NormalMissiles.Value = 50;
+                    NormalMissilesMax.Value = 50;
                     SuperMissiles.Value = 30;
+                    SuperMissilesMax.Value = 30;
                     PowerBombs.Value = 20;
+                    PowerBombsMax.Value = 20;
                     EnergyTanks.Value = 7;
+                    EnergyTanksMax.Value = 7;
                     AllowHiddenItems.Checked = true;
                     RouteGen.SelectedItem = "Speedrunner";
                     break;
-                case RandomizerDifficulty.Masochist:
+                case "Masochist":
                     NormalMissiles.Value = 15;
+                    NormalMissilesMax.Value = 15;
                     SuperMissiles.Value = 15;
+                    SuperMissilesMax.Value = 15;
                     PowerBombs.Value = 15;
+                    PowerBombsMax.Value = 15;
                     EnergyTanks.Value = 3;
+                    EnergyTanksMax.Value = 3;
                     AllowHiddenItems.Checked = true;
                     RouteGen.SelectedItem = "Masochist";
                     break;
@@ -64,6 +76,10 @@ namespace SuperMetroidRandomizer
                     SuperMissiles.Value = Settings.Default.CustomSuperMissiles;
                     PowerBombs.Value = Settings.Default.CustomPowerBombs;
                     EnergyTanks.Value = Settings.Default.CustomEnergyTanks;
+                    NormalMissilesMax.Value = Settings.Default.CustomNormalMissilesMax;
+                    SuperMissilesMax.Value = Settings.Default.CustomSuperMissilesMax;
+                    PowerBombsMax.Value = Settings.Default.CustomPowerBombsMax;
+                    EnergyTanksMax.Value = Settings.Default.CustomEnergyTanksMax;
                     AllowHiddenItems.Checked = Settings.Default.CustomHiddenItems;
                     RouteGen.SelectedItem = Settings.Default.CustomRouteGen;
                     break;
@@ -76,6 +92,10 @@ namespace SuperMetroidRandomizer
             Settings.Default.CustomSuperMissiles = SuperMissiles.Value;
             Settings.Default.CustomPowerBombs = PowerBombs.Value;
             Settings.Default.CustomEnergyTanks = EnergyTanks.Value;
+            Settings.Default.CustomNormalMissilesMax = NormalMissilesMax.Value;
+            Settings.Default.CustomSuperMissilesMax = SuperMissilesMax.Value;
+            Settings.Default.CustomPowerBombsMax = PowerBombsMax.Value;
+            Settings.Default.CustomEnergyTanksMax = EnergyTanksMax.Value;
             Settings.Default.CustomHiddenItems = AllowHiddenItems.Checked;
             Settings.Default.CustomRouteGen = RouteGen.SelectedItem.ToString();
 
@@ -109,36 +129,37 @@ namespace SuperMetroidRandomizer
 
         private void ValueChanged(object sender, EventArgs e)
         {
+            if (sender == NormalMissilesMax && NormalMissilesMax.Value < NormalMissiles.Value)
+                NormalMissilesMax.Value = NormalMissiles.Value;
+            else if (sender == SuperMissilesMax && SuperMissilesMax.Value < SuperMissiles.Value)
+                SuperMissilesMax.Value = SuperMissiles.Value;
+            else if (sender == PowerBombsMax && PowerBombsMax.Value < PowerBombs.Value)
+                PowerBombsMax.Value = PowerBombs.Value;
+            else if (sender == EnergyTanksMax && EnergyTanksMax.Value < EnergyTanks.Value)
+                EnergyTanksMax.Value = EnergyTanks.Value;
+
             decimal percent = CalculatePercentage();
-            if (percent > 100)
-                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = CustomSave.Enabled = false;
-            else if (percent == 100)
-            {
-                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = false;
-                CustomSave.Enabled = true;
-            }
+            if (percent > 100 && !RandomNoBlanks.Checked)
+                CustomSave.Enabled = false;
             else
-                NoFill.Enabled = RandomBlanks.Enabled = RandomNoBlanks.Enabled = CustomSave.Enabled = true;
+                CustomSave.Enabled = true;
 
             if (NoFill.Enabled && !NoFill.Checked)
             {
-                label1.Text = label1.Text.Replace("Max", "Min");
-                label2.Text = label2.Text.Replace("Max", "Min");
-                label3.Text = label3.Text.Replace("Max", "Min");
-                label4.Text = label4.Text.Replace("Max", "Min");
+                Minlbl.Visible = Maxlbl.Visible = NormalMissilesMax.Visible = SuperMissilesMax.Visible = PowerBombsMax.Visible = EnergyTanksMax.Visible = true;
             }
             else
-            {
-                label1.Text = label1.Text.Replace("Min", "Max");
-                label2.Text = label2.Text.Replace("Min", "Max");
-                label3.Text = label3.Text.Replace("Min", "Max");
-                label4.Text = label4.Text.Replace("Min", "Max");
-            }
+                Minlbl.Visible = Maxlbl.Visible = NormalMissilesMax.Visible = SuperMissilesMax.Visible = PowerBombsMax.Visible = EnergyTanksMax.Visible = false;
 
             if (RandomBlanks.Enabled && RandomBlanks.Checked)
                 Percent.Text = "??%";
             else if (RandomNoBlanks.Enabled && RandomNoBlanks.Checked)
-                Percent.Text = "100%";
+            {
+                if (percent > 100)
+                    Percent.Text = "100%";
+                else
+                    Percent.Text = string.Format("{0}%", percent);
+            }
             else
                 Percent.Text = string.Format("{0}%", percent);
         }
@@ -148,14 +169,14 @@ namespace SuperMetroidRandomizer
             decimal start = 0;
             switch(DifficultyDefault)
             {
-                case RandomizerDifficulty.Casual:
+                case "Casual":
                     start = 20;
                     break;
-                case RandomizerDifficulty.Speedrunner:
-                    start = 23;
+                case "Speedrunner":
+                    start = 20;
                     break;
-                case RandomizerDifficulty.Masochist:
-                    start = 16;
+                case "Masochist":
+                    start = 13;
                     break;
                 default:
                     start = 20;
@@ -163,6 +184,11 @@ namespace SuperMetroidRandomizer
             }
 
             start += (NormalMissiles.Value / 5) + (SuperMissiles.Value / 5) + (PowerBombs.Value / 5) + EnergyTanks.Value;
+            if (RandomNoBlanks.Checked)
+            {
+                start += ((NormalMissilesMax.Value - NormalMissiles.Value) / 5) + ((SuperMissilesMax.Value - SuperMissiles.Value) / 5);
+                start += ((PowerBombsMax.Value - PowerBombs.Value) / 5) + (EnergyTanksMax.Value - EnergyTanks.Value);
+            }
             return start;
         }
     }

--- a/SuperMetroidRandomizer/Customize.resx
+++ b/SuperMetroidRandomizer/Customize.resx
@@ -120,7 +120,4 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/SuperMetroidRandomizer/Customize.resx
+++ b/SuperMetroidRandomizer/Customize.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/SuperMetroidRandomizer/MainForm.Designer.cs
+++ b/SuperMetroidRandomizer/MainForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.output = new System.Windows.Forms.TextBox();
             this.process = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -46,7 +47,6 @@
             this.label5 = new System.Windows.Forms.Label();
             this.randomizerDifficulty = new System.Windows.Forms.ComboBox();
             this.controlsV11 = new System.Windows.Forms.Button();
-            this.browseV11 = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
             this.outputV11 = new System.Windows.Forms.TextBox();
             this.seedV11 = new System.Windows.Forms.TextBox();
@@ -55,7 +55,10 @@
             this.filenameV11 = new System.Windows.Forms.TextBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.controls = new System.Windows.Forms.Button();
+            this.CustomV11 = new System.Windows.Forms.Button();
+            this.browseV11 = new System.Windows.Forms.Button();
             this.save = new System.Windows.Forms.Button();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.groupBox1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -187,6 +190,7 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.CustomV11);
             this.tabPage1.Controls.Add(this.randomSpoiler);
             this.tabPage1.Controls.Add(this.report);
             this.tabPage1.Controls.Add(this.createSpoilerLog);
@@ -233,7 +237,7 @@
             // createSpoilerLog
             // 
             this.createSpoilerLog.AutoSize = true;
-            this.createSpoilerLog.Location = new System.Drawing.Point(192, 7);
+            this.createSpoilerLog.Location = new System.Drawing.Point(407, 0);
             this.createSpoilerLog.Name = "createSpoilerLog";
             this.createSpoilerLog.Size = new System.Drawing.Size(113, 17);
             this.createSpoilerLog.TabIndex = 21;
@@ -256,7 +260,8 @@
             this.randomizerDifficulty.Items.AddRange(new object[] {
             "Casual",
             "Speedrunner",
-            "Masochist"});
+            "Masochist",
+            "Custom"});
             this.randomizerDifficulty.Location = new System.Drawing.Point(64, 6);
             this.randomizerDifficulty.Name = "randomizerDifficulty";
             this.randomizerDifficulty.Size = new System.Drawing.Size(121, 21);
@@ -272,17 +277,6 @@
             this.controlsV11.Text = "Controls";
             this.controlsV11.UseVisualStyleBackColor = true;
             this.controlsV11.Click += new System.EventHandler(this.controlsV11_Click);
-            // 
-            // browseV11
-            // 
-            this.browseV11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.browseV11.Image = global::SuperMetroidRandomizer.Properties.Resources.MenuFileSaveIcon;
-            this.browseV11.Location = new System.Drawing.Point(495, 82);
-            this.browseV11.Name = "browseV11";
-            this.browseV11.Size = new System.Drawing.Size(25, 25);
-            this.browseV11.TabIndex = 15;
-            this.browseV11.UseVisualStyleBackColor = true;
-            this.browseV11.Click += new System.EventHandler(this.browseV11_Click);
             // 
             // label3
             // 
@@ -380,6 +374,28 @@
             this.controls.UseVisualStyleBackColor = true;
             this.controls.Click += new System.EventHandler(this.controls_Click);
             // 
+            // CustomV11
+            // 
+            this.CustomV11.Location = new System.Drawing.Point(191, 5);
+            this.CustomV11.Name = "CustomV11";
+            this.CustomV11.Size = new System.Drawing.Size(88, 23);
+            this.CustomV11.TabIndex = 36;
+            this.CustomV11.Text = "Customize...";
+            this.toolTip1.SetToolTip(this.CustomV11, "Select difficulty first to start with a template.");
+            this.CustomV11.UseVisualStyleBackColor = true;
+            this.CustomV11.Click += new System.EventHandler(this.CustomV11_Click);
+            // 
+            // browseV11
+            // 
+            this.browseV11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.browseV11.Image = global::SuperMetroidRandomizer.Properties.Resources.MenuFileSaveIcon;
+            this.browseV11.Location = new System.Drawing.Point(495, 82);
+            this.browseV11.Name = "browseV11";
+            this.browseV11.Size = new System.Drawing.Size(25, 25);
+            this.browseV11.TabIndex = 15;
+            this.browseV11.UseVisualStyleBackColor = true;
+            this.browseV11.Click += new System.EventHandler(this.browseV11_Click);
+            // 
             // save
             // 
             this.save.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -441,6 +457,8 @@
         private System.Windows.Forms.CheckBox createSpoilerLog;
         private System.Windows.Forms.Button report;
         private System.Windows.Forms.Button randomSpoiler;
+        private System.Windows.Forms.Button CustomV11;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }
 

--- a/SuperMetroidRandomizer/MainForm.cs
+++ b/SuperMetroidRandomizer/MainForm.cs
@@ -375,10 +375,7 @@ namespace SuperMetroidRandomizer
         private void CustomV11_Click(object sender, EventArgs e)
         {
             Customize customizeDialog = null;
-            if (randomizerDifficulty.SelectedItem.ToString() == "Custom")
-                customizeDialog = new Customize(RandomizerDifficulty.None);
-            else
-                customizeDialog = new Customize(GetRandomizerDifficulty());
+            customizeDialog = new Customize(randomizerDifficulty.SelectedItem.ToString());
             customizeDialog.ShowDialog();
 
             if (Settings.Default.UseCustomSettings)

--- a/SuperMetroidRandomizer/MainForm.cs
+++ b/SuperMetroidRandomizer/MainForm.cs
@@ -114,7 +114,10 @@ namespace SuperMetroidRandomizer
             filenameV11.Text = Settings.Default.OutputFileV11;
             createSpoilerLog.Checked = Settings.Default.CreateSpoilerLog;
             Text = string.Format("Super Metroid Randomizer v{0}", RandomizerVersion.CurrentDisplay);
-            randomizerDifficulty.SelectedItem = Settings.Default.RandomizerDifficulty;
+            if (Settings.Default.UseCustomSettings)
+                randomizerDifficulty.SelectedItem = "Custom";
+            else
+                randomizerDifficulty.SelectedItem = Settings.Default.RandomizerDifficulty;
             RunCheckUpdate();
         }
 
@@ -201,20 +204,33 @@ namespace SuperMetroidRandomizer
             if (seedV11.Text.ToUpper().Contains("C"))
             {
                 randomizerDifficulty.SelectedItem = "Casual";
+                Settings.Default.RandomizerDifficulty = "Casual";
                 seedV11.Text = seedV11.Text.ToUpper().Replace("C", "");
                 difficulty = RandomizerDifficulty.Casual;
+                Settings.Default.UseCustomSettings = false;
             }
             else if (seedV11.Text.ToUpper().Contains("S"))
             {
                 randomizerDifficulty.SelectedItem = "Speedrunner";
+                Settings.Default.RandomizerDifficulty = "Speedrunner";
                 seedV11.Text = seedV11.Text.ToUpper().Replace("S", "");
                 difficulty = RandomizerDifficulty.Speedrunner;
+                Settings.Default.UseCustomSettings = false;
             }
             else if (seedV11.Text.ToUpper().Contains("M"))
             {
                 randomizerDifficulty.SelectedItem = "Masochist";
+                Settings.Default.RandomizerDifficulty = "Masochist";
                 seedV11.Text = seedV11.Text.ToUpper().Replace("M", "");
                 difficulty = RandomizerDifficulty.Masochist;
+                Settings.Default.UseCustomSettings = false;
+            }
+            else if (seedV11.Text.ToUpper().Contains("X"))
+            {
+                randomizerDifficulty.SelectedItem = "Custom";
+                seedV11.Text = seedV11.Text.ToUpper().Replace("X", "");
+                difficulty = GetDifficultyFromString(Settings.Default.CustomRouteGen);
+                Settings.Default.UseCustomSettings = true;
             }
             //else if (seedV11.Text.ToUpper().Contains("I"))
             //{
@@ -228,12 +244,19 @@ namespace SuperMetroidRandomizer
                 {
                     case "Casual":
                         difficulty = RandomizerDifficulty.Casual;
+                        Settings.Default.UseCustomSettings = false;
                         break;
                     case "Speedrunner":
                         difficulty = RandomizerDifficulty.Speedrunner;
+                        Settings.Default.UseCustomSettings = false;
                         break;
                     case "Masochist":
                         difficulty = RandomizerDifficulty.Masochist;
+                        Settings.Default.UseCustomSettings = false;
+                        break;
+                    case "Custom":
+                        difficulty = GetDifficultyFromString(Settings.Default.CustomRouteGen);
+                        Settings.Default.UseCustomSettings = true;
                         break;
                     //case "Insane":
                     //    difficulty = RandomizerDifficulty.Insane;
@@ -245,6 +268,21 @@ namespace SuperMetroidRandomizer
                 }
             }
             return difficulty;
+        }
+
+        public RandomizerDifficulty GetDifficultyFromString(string str)
+        {
+            switch (str)
+            {
+                case "Casual":
+                    return RandomizerDifficulty.Casual;
+                case "Speedrunner":
+                    return RandomizerDifficulty.Speedrunner;
+                case "Masochist":
+                    return RandomizerDifficulty.Masochist;
+                default:
+                    return RandomizerDifficulty.Casual;
+            }
         }
 
         private void SetSeedBasedOnDifficulty()
@@ -259,6 +297,9 @@ namespace SuperMetroidRandomizer
                     break;
                 case "Insane":
                     seedV11.Text = string.Format("I{0:0000000}", (new SeedRandom()).Next(10000000));
+                    break;
+                case "Custom":
+                    seedV11.Text = string.Format("X{0:0000000}", (new SeedRandom()).Next(10000000));
                     break;
                 default:
                     seedV11.Text = string.Format("S{0:0000000}", (new SeedRandom()).Next(10000000));
@@ -329,6 +370,15 @@ namespace SuperMetroidRandomizer
 
             var difficulty = GetRandomizerDifficulty();
             CreateSpoilerLog(difficulty);
+        }
+
+        private void CustomV11_Click(object sender, EventArgs e)
+        {
+            var customizeDialog = new Customize(GetRandomizerDifficulty());
+            customizeDialog.ShowDialog();
+
+            if (Settings.Default.UseCustomSettings)
+                randomizerDifficulty.SelectedItem = "Custom";
         }
     }
 }

--- a/SuperMetroidRandomizer/MainForm.resx
+++ b/SuperMetroidRandomizer/MainForm.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SuperMetroidRandomizer/Properties/Settings.Designer.cs
+++ b/SuperMetroidRandomizer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SuperMetroidRandomizer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "10.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -152,6 +152,114 @@ namespace SuperMetroidRandomizer.Properties {
             }
             set {
                 this["CreateSpoilerLog"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("230")]
+        public decimal CustomNormalMissiles {
+            get {
+                return ((decimal)(this["CustomNormalMissiles"]));
+            }
+            set {
+                this["CustomNormalMissiles"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public decimal CustomSuperMissiles {
+            get {
+                return ((decimal)(this["CustomSuperMissiles"]));
+            }
+            set {
+                this["CustomSuperMissiles"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public decimal CustomPowerBombs {
+            get {
+                return ((decimal)(this["CustomPowerBombs"]));
+            }
+            set {
+                this["CustomPowerBombs"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("14")]
+        public decimal CustomEnergyTanks {
+            get {
+                return ((decimal)(this["CustomEnergyTanks"]));
+            }
+            set {
+                this["CustomEnergyTanks"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CustomHiddenItems {
+            get {
+                return ((bool)(this["CustomHiddenItems"]));
+            }
+            set {
+                this["CustomHiddenItems"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CustomRandomBlanks {
+            get {
+                return ((bool)(this["CustomRandomBlanks"]));
+            }
+            set {
+                this["CustomRandomBlanks"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CustomRandomNoBlanks {
+            get {
+                return ((bool)(this["CustomRandomNoBlanks"]));
+            }
+            set {
+                this["CustomRandomNoBlanks"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UseCustomSettings {
+            get {
+                return ((bool)(this["UseCustomSettings"]));
+            }
+            set {
+                this["UseCustomSettings"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Casual")]
+        public string CustomRouteGen {
+            get {
+                return ((string)(this["CustomRouteGen"]));
+            }
+            set {
+                this["CustomRouteGen"] = value;
             }
         }
     }

--- a/SuperMetroidRandomizer/Properties/Settings.Designer.cs
+++ b/SuperMetroidRandomizer/Properties/Settings.Designer.cs
@@ -262,5 +262,53 @@ namespace SuperMetroidRandomizer.Properties {
                 this["CustomRouteGen"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("230")]
+        public decimal CustomNormalMissilesMax {
+            get {
+                return ((decimal)(this["CustomNormalMissilesMax"]));
+            }
+            set {
+                this["CustomNormalMissilesMax"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public decimal CustomSuperMissilesMax {
+            get {
+                return ((decimal)(this["CustomSuperMissilesMax"]));
+            }
+            set {
+                this["CustomSuperMissilesMax"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public decimal CustomPowerBombsMax {
+            get {
+                return ((decimal)(this["CustomPowerBombsMax"]));
+            }
+            set {
+                this["CustomPowerBombsMax"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("14")]
+        public decimal CustomEnergyTanksMax {
+            get {
+                return ((decimal)(this["CustomEnergyTanksMax"]));
+            }
+            set {
+                this["CustomEnergyTanksMax"] = value;
+            }
+        }
     }
 }

--- a/SuperMetroidRandomizer/Properties/Settings.settings
+++ b/SuperMetroidRandomizer/Properties/Settings.settings
@@ -35,5 +35,32 @@
     <Setting Name="CreateSpoilerLog" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CustomNormalMissiles" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">230</Value>
+    </Setting>
+    <Setting Name="CustomSuperMissiles" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+    <Setting Name="CustomPowerBombs" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+    <Setting Name="CustomEnergyTanks" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">14</Value>
+    </Setting>
+    <Setting Name="CustomHiddenItems" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CustomRandomBlanks" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CustomRandomNoBlanks" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="UseCustomSettings" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CustomRouteGen" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Casual</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SuperMetroidRandomizer/Properties/Settings.settings
+++ b/SuperMetroidRandomizer/Properties/Settings.settings
@@ -62,5 +62,17 @@
     <Setting Name="CustomRouteGen" Type="System.String" Scope="User">
       <Value Profile="(Default)">Casual</Value>
     </Setting>
+    <Setting Name="CustomNormalMissilesMax" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">230</Value>
+    </Setting>
+    <Setting Name="CustomSuperMissilesMax" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+    <Setting Name="CustomPowerBombsMax" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+    <Setting Name="CustomEnergyTanksMax" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">14</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SuperMetroidRandomizer/Random/RandomizerV11.cs
+++ b/SuperMetroidRandomizer/Random/RandomizerV11.cs
@@ -283,29 +283,10 @@ namespace SuperMetroidRandomizer.Random
                     pool.AddRange(new List<ItemType>
                                     {
                                         ItemType.MorphingBall, ItemType.Bomb, ItemType.ChargeBeam,
-                                        ItemType.ChargeBeam, ItemType.ChargeBeam, ItemType.ChargeBeam,
                                         ItemType.Spazer, ItemType.VariaSuit, ItemType.HiJumpBoots,
                                         ItemType.SpeedBooster, ItemType.WaveBeam, ItemType.GrappleBeam,
                                         ItemType.SpringBall, ItemType.IceBeam, ItemType.XRayScope,
                                         ItemType.ReserveTank
-                                    });
-                    break;
-                case "Speedrunner":
-                    pool.AddRange(new List<ItemType>
-                                    {
-                                        ItemType.ChargeBeam, ItemType.ChargeBeam, ItemType.ChargeBeam
-                                    });
-                    goto case "Casual";
-                case "Casual":
-                    pool.AddRange(new List<ItemType>
-                                    {
-                                        ItemType.MorphingBall, ItemType.Bomb, ItemType.ChargeBeam,
-                                        ItemType.Spazer, ItemType.VariaSuit, ItemType.HiJumpBoots,
-                                        ItemType.SpeedBooster, ItemType.WaveBeam, ItemType.GrappleBeam,
-                                        ItemType.GravitySuit, ItemType.SpaceJump, ItemType.SpringBall,
-                                        ItemType.PlasmaBeam, ItemType.IceBeam, ItemType.ScrewAttack,
-                                        ItemType.XRayScope, ItemType.ReserveTank, ItemType.ReserveTank,
-                                        ItemType.ReserveTank, ItemType.ReserveTank
                                     });
                     break;
                 default:
@@ -323,9 +304,13 @@ namespace SuperMetroidRandomizer.Random
             }
 
             decimal addMissiles = Settings.Default.CustomNormalMissiles / 5;
+            decimal addMissilesMax = Settings.Default.CustomNormalMissilesMax / 5;
             decimal addSMissiles = Settings.Default.CustomSuperMissiles / 5;
+            decimal addSMissilesMax = Settings.Default.CustomSuperMissilesMax / 5;
             decimal addPBombs = Settings.Default.CustomPowerBombs / 5;
+            decimal addPBombsMax = Settings.Default.CustomPowerBombsMax / 5;
             decimal addETanks = Settings.Default.CustomEnergyTanks;
+            decimal addETanksMax = Settings.Default.CustomEnergyTanksMax;
 
             for (int i = 0; i < addMissiles; i++)
                 pool.Add(ItemType.Missile);
@@ -335,32 +320,47 @@ namespace SuperMetroidRandomizer.Random
                 pool.Add(ItemType.PowerBomb);
             for (int i = 0; i < addETanks; i++)
                 pool.Add(ItemType.EnergyTank);
-
-            decimal ItemsRemaining = 100 - pool.Count;
-            if (ItemsRemaining > 0 && (Settings.Default.CustomRandomBlanks || Settings.Default.CustomRandomNoBlanks))
+            
+            if (pool.Count < 100 && (Settings.Default.CustomRandomBlanks || Settings.Default.CustomRandomNoBlanks))
             {
-                for (int i = 0; i < ItemsRemaining; i++)
+                while (pool.Count < 100)
                 {
                     int rand = 0; 
                     if (Settings.Default.CustomRandomBlanks)
-                        rand = random.Next(5);
+                        rand = random.Next(8);
                     else if (Settings.Default.CustomRandomNoBlanks)
                         rand = random.Next(4);
                     switch (rand)
                     {
                         case 0:
-                            pool.Add(ItemType.Missile);
+                            if (addMissiles < addMissilesMax)
+                            {
+                                pool.Add(ItemType.Missile);
+                                ++addMissiles;
+                            }
                             break;
                         case 1:
-                            pool.Add(ItemType.SuperMissile);
+                            if (addSMissiles < addSMissilesMax)
+                            {
+                                pool.Add(ItemType.SuperMissile);
+                                ++addSMissiles;
+                            }
                             break;
                         case 2:
-                            pool.Add(ItemType.PowerBomb);
+                            if (addPBombs < addPBombsMax)
+                            {
+                                pool.Add(ItemType.PowerBomb);
+                                ++addPBombs;
+                            }
                             break;
                         case 3:
-                            pool.Add(ItemType.EnergyTank);
+                            if (addETanks < addETanksMax)
+                            {
+                                pool.Add(ItemType.EnergyTank);
+                                ++addETanks;
+                            }
                             break;
-                        case 4:
+                        default:
                             pool.Add(ItemType.Nothing);
                             break;
                     }

--- a/SuperMetroidRandomizer/Random/RandomizerV11.cs
+++ b/SuperMetroidRandomizer/Random/RandomizerV11.cs
@@ -58,6 +58,8 @@ namespace SuperMetroidRandomizer.Random
         {
             string usedFilename = FileName.Fix(filename, string.Format(romLocations.SeedFileString, seed));
             var hideLocations = !(romLocations is RomLocationsCasual);
+            if (Settings.Default.UseCustomSettings && !Settings.Default.CustomHiddenItems)
+                hideLocations = false;
 
             using (var rom = new FileStream(usedFilename, FileMode.OpenOrCreate))
             {
@@ -259,13 +261,113 @@ namespace SuperMetroidRandomizer.Random
         {
             romLocations.ResetLocations();
             haveItems = new List<ItemType>();
-            itemPool = romLocations.GetItemPool(random);
+            if (Settings.Default.UseCustomSettings)
+                itemPool = CreateItemPool(random);
+            else
+                itemPool = romLocations.GetItemPool(random);
             var unavailableLocations = romLocations.GetUnavailableLocations(itemPool);
 
             for (int i = itemPool.Count; i < 100 - unavailableLocations.Count; i++)
             {
                 itemPool.Add(ItemType.Nothing);
             }
+        }
+
+        private List<ItemType> CreateItemPool(SeedRandom random)
+        {
+            List<ItemType> pool = new List<ItemType>();
+
+            switch (Settings.Default.CustomRouteGen)
+            {
+                case "Masochist":
+                    pool.AddRange(new List<ItemType>
+                                    {
+                                        ItemType.MorphingBall, ItemType.Bomb, ItemType.ChargeBeam,
+                                        ItemType.ChargeBeam, ItemType.ChargeBeam, ItemType.ChargeBeam,
+                                        ItemType.Spazer, ItemType.VariaSuit, ItemType.HiJumpBoots,
+                                        ItemType.SpeedBooster, ItemType.WaveBeam, ItemType.GrappleBeam,
+                                        ItemType.SpringBall, ItemType.IceBeam, ItemType.XRayScope,
+                                        ItemType.ReserveTank
+                                    });
+                    break;
+                case "Speedrunner":
+                    pool.AddRange(new List<ItemType>
+                                    {
+                                        ItemType.ChargeBeam, ItemType.ChargeBeam, ItemType.ChargeBeam
+                                    });
+                    goto case "Casual";
+                case "Casual":
+                    pool.AddRange(new List<ItemType>
+                                    {
+                                        ItemType.MorphingBall, ItemType.Bomb, ItemType.ChargeBeam,
+                                        ItemType.Spazer, ItemType.VariaSuit, ItemType.HiJumpBoots,
+                                        ItemType.SpeedBooster, ItemType.WaveBeam, ItemType.GrappleBeam,
+                                        ItemType.GravitySuit, ItemType.SpaceJump, ItemType.SpringBall,
+                                        ItemType.PlasmaBeam, ItemType.IceBeam, ItemType.ScrewAttack,
+                                        ItemType.XRayScope, ItemType.ReserveTank, ItemType.ReserveTank,
+                                        ItemType.ReserveTank, ItemType.ReserveTank
+                                    });
+                    break;
+                default:
+                    pool.AddRange(new List<ItemType>
+                                    {
+                                        ItemType.MorphingBall, ItemType.Bomb, ItemType.ChargeBeam,
+                                        ItemType.Spazer, ItemType.VariaSuit, ItemType.HiJumpBoots,
+                                        ItemType.SpeedBooster, ItemType.WaveBeam, ItemType.GrappleBeam,
+                                        ItemType.GravitySuit, ItemType.SpaceJump, ItemType.SpringBall,
+                                        ItemType.PlasmaBeam, ItemType.IceBeam, ItemType.ScrewAttack,
+                                        ItemType.XRayScope, ItemType.ReserveTank, ItemType.ReserveTank,
+                                        ItemType.ReserveTank, ItemType.ReserveTank
+                                    });
+                    break;
+            }
+
+            decimal addMissiles = Settings.Default.CustomNormalMissiles / 5;
+            decimal addSMissiles = Settings.Default.CustomSuperMissiles / 5;
+            decimal addPBombs = Settings.Default.CustomPowerBombs / 5;
+            decimal addETanks = Settings.Default.CustomEnergyTanks;
+
+            for (int i = 0; i < addMissiles; i++)
+                pool.Add(ItemType.Missile);
+            for (int i = 0; i < addSMissiles; i++)
+                pool.Add(ItemType.SuperMissile);
+            for (int i = 0; i < addPBombs; i++)
+                pool.Add(ItemType.PowerBomb);
+            for (int i = 0; i < addETanks; i++)
+                pool.Add(ItemType.EnergyTank);
+
+            decimal ItemsRemaining = 100 - pool.Count;
+            if (ItemsRemaining > 0 && (Settings.Default.CustomRandomBlanks || Settings.Default.CustomRandomNoBlanks))
+            {
+                for (int i = 0; i < ItemsRemaining; i++)
+                {
+                    int rand = 0; 
+                    if (Settings.Default.CustomRandomBlanks)
+                        rand = random.Next(5);
+                    else if (Settings.Default.CustomRandomNoBlanks)
+                        rand = random.Next(4);
+                    switch (rand)
+                    {
+                        case 0:
+                            pool.Add(ItemType.Missile);
+                            break;
+                        case 1:
+                            pool.Add(ItemType.SuperMissile);
+                            break;
+                        case 2:
+                            pool.Add(ItemType.PowerBomb);
+                            break;
+                        case 3:
+                            pool.Add(ItemType.EnergyTank);
+                            break;
+                        case 4:
+                            pool.Add(ItemType.Nothing);
+                            break;
+                    }
+                }
+            }
+
+            return pool;
         }
     }
 }

--- a/SuperMetroidRandomizer/Rom/RomLocationsCasual.cs
+++ b/SuperMetroidRandomizer/Rom/RomLocationsCasual.cs
@@ -2,15 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using SuperMetroidRandomizer.Random;
+using SuperMetroidRandomizer.Properties;
 
 namespace SuperMetroidRandomizer.Rom
 {
     public class RomLocationsCasual : IRomLocations
     {
         public List<Location> Locations { get; set; }
-        public string DifficultyName { get { return "Casual"; } }
-        public string SeedFileString { get { return "C{0:0000000}"; } }
-        public string SeedRomString { get { return "SMRv{0} C{1}"; } }
+        public string DifficultyName { get { return (!Settings.Default.UseCustomSettings) ? "Casual" : "Casual (Custom)"; } }
+        public string SeedFileString { get { return (!Settings.Default.UseCustomSettings) ? "C{0:0000000}" : "X{0:0000000}"; } }
+        public string SeedRomString { get { return (!Settings.Default.UseCustomSettings) ? "SMRv{0} C{1}" : "SMRv{0} X{1}"; } }
 
         public void ResetLocations()
         {

--- a/SuperMetroidRandomizer/Rom/RomLocationsMasochist.cs
+++ b/SuperMetroidRandomizer/Rom/RomLocationsMasochist.cs
@@ -2,15 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using SuperMetroidRandomizer.Random;
+using SuperMetroidRandomizer.Properties;
 
 namespace SuperMetroidRandomizer.Rom
 {
     public class RomLocationsMasochist : IRomLocations
     {
         public List<Location> Locations { get; set; }
-        public string DifficultyName { get { return "Masochist"; } }
-        public string SeedFileString { get { return "M{0:0000000}"; } }
-        public string SeedRomString { get { return "SMRv{0} M{1}"; } }
+        public string DifficultyName { get { return (!Settings.Default.UseCustomSettings) ? "Masochist": "Masochist (Custom)"; } }
+        public string SeedFileString { get { return (!Settings.Default.UseCustomSettings) ? "M{0:0000000}" : "X{0:0000000}"; } }
+        public string SeedRomString { get { return (!Settings.Default.UseCustomSettings) ? "SMRv{0} M{1}" : "SMRv{0} X{1}"; } }
 
         public void ResetLocations()
         {

--- a/SuperMetroidRandomizer/Rom/RomLocationsSpeedrunner.cs
+++ b/SuperMetroidRandomizer/Rom/RomLocationsSpeedrunner.cs
@@ -2,15 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using SuperMetroidRandomizer.Random;
+using SuperMetroidRandomizer.Properties;
 
 namespace SuperMetroidRandomizer.Rom
 {
     public class RomLocationsSpeedrunner : IRomLocations
     {
         public List<Location> Locations { get; set; }
-        public string DifficultyName { get { return "Speedrunner"; } }
-        public string SeedFileString { get { return "S{0:0000000}"; } }
-        public string SeedRomString { get { return "SMRv{0} S{1}"; } }
+        public string DifficultyName { get { return (!Settings.Default.UseCustomSettings) ? "Speedrunner" : "Speedrunner (Custom)"; } }
+        public string SeedFileString { get { return (!Settings.Default.UseCustomSettings) ? "S{0:0000000}" : "X{0:0000000}"; } }
+        public string SeedRomString { get { return (!Settings.Default.UseCustomSettings) ? "SMRv{0} S{1}" : "SMRv{0} X{1}"; } }
 
         public void ResetLocations()
         {

--- a/SuperMetroidRandomizer/SuperMetroidRandomizer.csproj
+++ b/SuperMetroidRandomizer/SuperMetroidRandomizer.csproj
@@ -49,6 +49,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Customize.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Customize.Designer.cs">
+      <DependentUpon>Customize.cs</DependentUpon>
+    </Compile>
     <Compile Include="IO\FileName.cs" />
     <Compile Include="Net\RandomizerVersion.cs" />
     <Compile Include="Rom\Controller.cs" />
@@ -80,6 +86,9 @@
     <Compile Include="Random\SeedRandom.cs" />
     <EmbeddedResource Include="Controls.resx">
       <DependentUpon>Controls.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Customize.resx">
+      <DependentUpon>Customize.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/SuperMetroidRandomizer/app.config
+++ b/SuperMetroidRandomizer/app.config
@@ -67,6 +67,18 @@
             <setting name="CustomRouteGen" serializeAs="String">
                 <value>Casual</value>
             </setting>
+            <setting name="CustomNormalMissilesMax" serializeAs="String">
+                <value>230</value>
+            </setting>
+            <setting name="CustomSuperMissilesMax" serializeAs="String">
+                <value>50</value>
+            </setting>
+            <setting name="CustomPowerBombsMax" serializeAs="String">
+                <value>50</value>
+            </setting>
+            <setting name="CustomEnergyTanksMax" serializeAs="String">
+                <value>14</value>
+            </setting>
         </SuperMetroidRandomizer.Properties.Settings>
     </userSettings>
 </configuration>

--- a/SuperMetroidRandomizer/app.config
+++ b/SuperMetroidRandomizer/app.config
@@ -40,6 +40,33 @@
             <setting name="CreateSpoilerLog" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="CustomNormalMissiles" serializeAs="String">
+                <value>230</value>
+            </setting>
+            <setting name="CustomSuperMissiles" serializeAs="String">
+                <value>50</value>
+            </setting>
+            <setting name="CustomPowerBombs" serializeAs="String">
+                <value>50</value>
+            </setting>
+            <setting name="CustomEnergyTanks" serializeAs="String">
+                <value>14</value>
+            </setting>
+            <setting name="CustomHiddenItems" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="CustomRandomBlanks" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="CustomRandomNoBlanks" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="UseCustomSettings" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="CustomRouteGen" serializeAs="String">
+                <value>Casual</value>
+            </setting>
         </SuperMetroidRandomizer.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Adds the ability to customize the amount of Missiles, Super Missiles, Power Bombs, and Energy Tanks obtainable.
Adds the option to randomize what is obtained, with or without blank spots.

Could be further expanded to enable/disable any items.

TODO: Modify Seed input for Custom difficulties, currently it doesn't remember the new customization options. If those are inputted correctly though, and items are set to be randomized, the seed will generate those the same. (I would have changed the seed myself, but I don't know where to start on that.)